### PR TITLE
Release 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.2 (2021-06-09)
+
+- Added the `sky-href` class for link style, added handling for null config and resolver, and switched to using the `hidden` attribute when hiding `skyHref` links. [#29](https://github.com/blackbaud/skyux-router/pull/29)
+
 # 4.2.1 (2021-06-03)
 
 - Fixed `SkyAppLinkExternalDirective` to properly include query parameters on link URLs. [#27](https://github.com/blackbaud/skyux-router/pull/27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.2.2 (2021-06-09)
 
-- Added the `sky-href` class for link style, added handling for null config and resolver, and switched to using the `hidden` attribute when hiding `skyHref` links. [#29](https://github.com/blackbaud/skyux-router/pull/29)
+- Added the `sky-href` class for the link style, added handling for the null config and resolver, and switched to using the `hidden` attribute when hiding `skyHref` links. [#29](https://github.com/blackbaud/skyux-router/pull/29)
 
 # 4.2.1 (2021-06-03)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/router",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1163,9 +1163,9 @@
       }
     },
     "@blackbaud/auth-client": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/auth-client/-/auth-client-2.46.0.tgz",
-      "integrity": "sha512-xgHezmvEtqXRTGRVXGwJSXquSQYHEyBVP131VyvELtgsHHn3cVkK0HtFu6WhKSwp/xTxBaEWqTMEZlIEvv9y7g==",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/auth-client/-/auth-client-2.47.0.tgz",
+      "integrity": "sha512-GN1DpWB4trxMOc/2DWu3qH45CVC52UJ4pShF7hEfRJCaSTIISsDrSlYGiL9pc9z/crWkg0qA5H/AsiFLdsjDIw==",
       "dev": true,
       "requires": {
         "@types/jwt-decode": "2.2.1",
@@ -1627,9 +1627,9 @@
       }
     },
     "@skyux/router": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@skyux/router/-/router-4.2.0.tgz",
-      "integrity": "sha512-HqR7xjICHmsZoc2SKqONXTBbYHX3EPbTBjqJz11Fe60FSCFF8efJj4zhMViVN4jMCJD3eyeUVIsWzVf0zXsQZQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@skyux/router/-/router-4.2.1.tgz",
+      "integrity": "sha512-CtKQpWUKekueg/R0s/PABv0zcCDOP88qDCz3jdJrZwYvBOQxWY2GhkTRP41w3tcTbbs/9tqu8euBXuT/f2gOdA==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/router",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "SKY UX Router",
   "scripts": {
     "build": "skyux build-public-library",
@@ -37,7 +37,7 @@
     "@angular/platform-browser": "9.1.13",
     "@angular/platform-browser-dynamic": "9.1.13",
     "@angular/router": "9.1.13",
-    "@blackbaud/auth-client": "2.46.0",
+    "@blackbaud/auth-client": "2.47.0",
     "@skyux-sdk/builder": "4.9.0",
     "@skyux-sdk/builder-plugin-skyux": "4.1.4",
     "@skyux-sdk/e2e": "4.0.2",
@@ -50,7 +50,7 @@
     "@skyux/indicators": "4.9.2",
     "@skyux/modals": "4.5.3",
     "@skyux/omnibar-interop": "4.0.1",
-    "@skyux/router": "4.2.0",
+    "@skyux/router": "4.2.1",
     "@skyux/theme": "4.16.3",
     "codelyzer": "5.2.2",
     "rxjs": "6.6.7",


### PR DESCRIPTION
- Added the `sky-href` class for link style, added handling for null config and resolver, and switched to using the `hidden` attribute when hiding `skyHref` links. [#29](https://github.com/blackbaud/skyux-router/pull/29)
